### PR TITLE
fix: verify that namespaces passed in arg are watched by kube-ns-suspender

### DIFF
--- a/cmd/suspend.go
+++ b/cmd/suspend.go
@@ -81,6 +81,19 @@ Usage examples:
 			status := "done\n"
 			s := utils.CreateSpinner("suspending namespace " + n)
 			s.Start()
+
+			ns, err := a.Clientset.CoreV1().Namespaces().Get(context.TODO(), n, metav1.GetOptions{})
+			if err != nil {
+				a.Logger.Error().Err(err).Msgf("cannot get namespace '%s'", n)
+				s.Stop()
+				continue
+			}
+			if err := utils.IsNamespaceWatched(ns, a.AnnotationsNames.Prefix+"/"+a.AnnotationsNames.ControllerName, a.ControllerName); err != nil {
+				a.Logger.Error().Err(err).Msgf("namespace '%s' is not watched", n)
+				s.Stop()
+				continue
+			}
+
 			if err := a.UpdateNamespace(n, app.SuspendedState); err != nil {
 				a.Logger.Error().Err(err).Msgf("cannot suspend namespace '%s'", n)
 				status = "failed\n"

--- a/cmd/unsuspend.go
+++ b/cmd/unsuspend.go
@@ -76,6 +76,19 @@ Usage example:
 			status := "done\n"
 			s := utils.CreateSpinner("unsuspending namespace " + n)
 			s.Start()
+
+			ns, err := a.Clientset.CoreV1().Namespaces().Get(context.TODO(), n, metav1.GetOptions{})
+			if err != nil {
+				a.Logger.Error().Err(err).Msgf("cannot get namespace '%s'", n)
+				s.Stop()
+				continue
+			}
+			if err := utils.IsNamespaceWatched(ns, a.AnnotationsNames.Prefix+"/"+a.AnnotationsNames.ControllerName, a.ControllerName); err != nil {
+				a.Logger.Error().Err(err).Msgf("namespace '%s' is not watched", n)
+				s.Stop()
+				continue
+			}
+
 			if err := a.UpdateNamespace(n, app.RunningState); err != nil {
 				a.Logger.Error().Err(err).Msgf("cannot unsuspend namespace '%s'", n)
 				status = "failed\n"

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"fmt"
 	"time"
 
 	"github.com/briandowns/spinner"
@@ -40,4 +41,15 @@ func CreateSpinner(suffix string) *spinner.Spinner {
 	s := spinner.New(spinner.CharSets[14], 100*time.Millisecond)
 	s.Suffix = " " + suffix
 	return s
+}
+
+func IsNamespaceWatched(ns *v1.Namespace, controllerNameFullAnnot, controllerName string) error {
+	val, ok := ns.Annotations[controllerNameFullAnnot]
+	if !ok {
+		return fmt.Errorf("this namespace is not watched by kube-ns-suspender")
+	}
+	if val != controllerName {
+		return fmt.Errorf("namespace's controller name does not match the configured controller name")
+	}
+	return nil
 }


### PR DESCRIPTION
this PR closes #1
